### PR TITLE
Features/redis

### DIFF
--- a/django_sse/decorators.py
+++ b/django_sse/decorators.py
@@ -9,11 +9,12 @@ import types
 import time
 
 class Sse(object):
-    def __init__(self, retry=None):
+    def __init__(self, response_class=Response, retry=None):
+        self.response_class = response_class
         self.retry = retry
 
     def __call__(self, viewfunc):
-        response = Response()
+        response = self.response_class()
         if self.retry is not None:
             response.set_retry(self.retry)
 
@@ -36,13 +37,14 @@ class Sse(object):
         return _inner
 
 
-class StreamSse(object):
-    def __init__(self, retry=DEFAULT_RETRY_TIMEOUT, sleep=1):
+class StreamSse(Sse):
+    def __init__(self, response_class=Response, retry=DEFAULT_RETRY_TIMEOUT, sleep=1):
+        self.response_class = response_class
         self.retry = retry
         self.sleep = sleep
 
     def __call__(self, viewfunc):
-        response = Response()
+        response = self.response_class()
 
         if self.retry is not None:
             response.set_retry(self.retry)
@@ -73,19 +75,19 @@ class StreamSse(object):
         return _inner
 
 
-def is_sse_method(retry=DEFAULT_RETRY_TIMEOUT):
+def is_sse_method(response_class=Response, retry=DEFAULT_RETRY_TIMEOUT):
     """
     Declare class view method as sse method.
     """
 
     if isinstance(retry, (types.FunctionType, types.MethodType)):
-        return Sse()(retry)
+        return Sse(response_class=response_class)(retry)
     
-    return Sse(retry)
+    return Sse(response_class=response_class, retry=retry)
 
 
-def is_stream_sse_method(retry=DEFAULT_RETRY_TIMEOUT, sleep=DEFAULT_SLEEP):
+def is_stream_sse_method(response_class=Response, retry=DEFAULT_RETRY_TIMEOUT, sleep=DEFAULT_SLEEP):
     """
     Declare class view method as sse stream method.
     """
-    return StreamSse(retry=retry, sleep=sleep)
+    return StreamSse(response_class=response_class, retry=retry, sleep=sleep)

--- a/django_sse/utils.py
+++ b/django_sse/utils.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+import json
+
+
+SSE_REDIS_BROKER_DEFAULT = {
+    'HOST': 'localhost',
+    'PORT': 6379,
+    'DB': 0
+}
+
+
+def redis_connection():
+    import redis
+
+    params = SSE_REDIS_BROKER_DEFAULT.copy()
+    params.update(getattr(settings, 'SSE_REDIS_BROKER', {}))
+
+    lowercased_params = dict((k.lower(), v) for k, v in params.iteritems())
+
+    r = redis.StrictRedis(**lowercased_params)
+
+    return r
+
+
+def redis_add_message(event, text):
+    from django_sse.utils import redis_connection
+
+    r = redis_connection()
+    r.publish('sse', json.dumps([event, text]))


### PR DESCRIPTION
I've added the option to specific a custom response class for the decorator, and added a response class that can subscribe to Redis.

you can specify how to connect to Redis via the `SSE_REDIS_BROKER` setting, which defaults to:

```
SSE_REDIS_BROKER = {
    'HOST': 'localhost',
    'PORT': 6379,
    'DB': 0
}
```

then, you can implement your view this way:

```
from django_sse.decorators import is_stream_sse_method
from django_sse.response import RedisPubSubResponse

class SSEView(View):
    http_method_names = ['get', ]

    @is_stream_sse_method(response_class=RedisPubSubResponse, sleep=1)
    def get(self, request, *args, **kwargs):
        now_date = unicode(now())
        self.sse.event_date(text=now_date)
```

you can push events to clients from anywhere in your code by using `redis_add_message`:

```
from django_sse.utils import redis_add_message

redis_add_message('event_name', 'text')
```
