### PR TITLE
allow all http methods

### DIFF
--- a/django_sse/views.py
+++ b/django_sse/views.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from django.views.generic import View
+from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponse
+from django.utils.decorators import method_decorator
 from sse import Sse
 
 
@@ -20,7 +22,8 @@ class BaseSseView(View):
             for bufferitem in self.sse:
                 yield bufferitem
 
-    def get(self, request, *args, **kwargs):
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request, *args, **kwargs):
         self.sse = Sse()
 
         response = HttpResponse(self._iterator(), content_type="text/event-stream")


### PR DESCRIPTION
Some polyfills (at least https://github.com/Yaffle/EventSource) use POST requests to work around browser bugs (see https://github.com/Yaffle/EventSource/blob/master/eventsource.js#L354).

While it makes most sense to me to only allow GET requests, I've glanced at the SSE specification, and I couldn't find any indication that any particular HTTP verb must be used.
