### PR TITLE
Changing redis channel does not work

### DIFF
--- a/django_sse/views.py
+++ b/django_sse/views.py
@@ -26,6 +26,10 @@ class BaseSseView(View):
     def dispatch(self, request, *args, **kwargs):
         self.sse = Sse()
 
+        self.request = request
+        self.args = args
+        self.kwargs = kwargs
+
         response = HttpResponse(self._iterator(), content_type="text/event-stream")
         response['Cache-Control'] = 'no-cache'
         response['Software'] = 'django-sse'


### PR DESCRIPTION
The attributes self.request, serf.args and self.kwargs of a generic.View are created in the dispatch method of django.views.generic.View.
By overridding this method in BaseSseView and not implementing these attributes, whenever a call is made to self. request or self.kwargs, results in runtime error.
