### PR TITLE
Fixes TypError with RedisQueueView on Python 3.3

### DIFF
--- a/django_sse/redisqueue.py
+++ b/django_sse/redisqueue.py
@@ -66,7 +66,7 @@ class RedisQueueView(BaseSseView):
 
         for message in pubsub.listen():
             if message['type'] == 'message':
-                event, data = json.loads(message['data'])
+                event, data = json.loads(message['data'].decode('utf-8'))
                 self.sse.add_message(event, data)
                 yield
 


### PR DESCRIPTION
This fixes a TypeError on Python 3.3.
I've tested this fix on python 2.7 and Python 3.3 and it works in both versions.

FYI, the original Traceback was:

```

Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.3.0/Frameworks/Python.framework/Versions/3.3/lib/python3.3/wsgiref/handlers.py", line 138, in run
[16/Apr/2013 10:26:28] "POST /sse_incr/ HTTP/1.1" 200 2
    self.finish_response()
  File "/usr/local/Cellar/python3/3.3.0/Frameworks/Python.framework/Versions/3.3/lib/python3.3/wsgiref/handlers.py", line 178, in finish_response
    for data in self.result:
  File "/Users/flavio/Envs/django-push-demo3k/lib/python3.3/site-packages/django/http/response.py", line 223, in __next__
    return self.make_bytes(next(self._iterator))
  File "/Users/flavio/Envs/django-push-demo3k/lib/python3.3/site-packages/django_sse/views.py", line 26, in _iterator
    for subiterator in self.iterator():
  File "/Users/flavio/Envs/django-push-demo3k/lib/python3.3/site-packages/django_sse/redisqueue.py", line 69, in iterator
    event, data = json.loads(message['data'])
  File "/usr/local/Cellar/python3/3.3.0/Frameworks/Python.framework/Versions/3.3/lib/python3.3/json/__init__.py", line 309, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python3/3.3.0/Frameworks/Python.framework/Versions/3.3/lib/python3.3/json/decoder.py", line 352, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
TypeError: can't use a string pattern on a bytes-like object
```
